### PR TITLE
Expand `strict` definition to allow for missing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Once activated and configured you can use the `rev()` function in your templates
 <link rel="stylesheet" href="{{ rev('css/main.css') }}">
 ```
 
-In some cases (e.g. when building additional files that aren't available in the manifest file), you can prevent the extension from throwing an exception about a missing file mapping by setting the optional `$strict` parameter to `false`: 
+In some cases (e.g. when building additional files that aren't available in the manifest file or are files that are served via proxy), you can prevent the extension from throwing an exception about a missing file mapping by setting the optional `$strict` parameter to `false`: 
 
 ```
 <link rel="stylesheet" href="{{ rev('css/not-available-in-manifest.css', false) }}">

--- a/src/utilities/FilenameRev.php
+++ b/src/utilities/FilenameRev.php
@@ -42,12 +42,15 @@ class FilenameRev
     public function rev($file, $strict)
     {
         $manifest = $this->getAbsolutePath($this->manifestPath);
+        $revvedFile = null;
 
-        $revvedFile = $this->manifestExists($manifest) && ($strict || $this->existsInManifest($manifest, $file)) ?
-            $this->revUsingManifest($manifest, $file) :
-            $this->appendQueryString($file);
+        if ($this->manifestExists($manifest) && ($strict || $this->existsInManifest($manifest, $file))) {
+            $revvedFile = $this->revUsingManifest($manifest, $file);
+        } elseif ($strict || file_exists($file)) {
+            $revvedFile = $this->appendQueryString($file);
+        }
 
-        return $this->prependAssetPrefix($revvedFile);
+        return $this->prependAssetPrefix($revvedFile ?? $file);
     }
 
     protected function manifestExists($manifestPath)

--- a/tests/utilities/FilenameRevTest.php
+++ b/tests/utilities/FilenameRevTest.php
@@ -91,6 +91,22 @@ class FilenameRevTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function it_returns_the_assets_path_if_the_file_doesnt_exist_and_strict_is_false()
+    {
+        $asset = 'missing-file.css';
+        $assetPrefix = '/asset/base/path';
+
+        $revver = new FilenameRev(null, null, $assetPrefix);
+
+        $this->assertEquals(
+            $assetPrefix . $asset,
+            $revver->rev($asset, false)
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_prepends_the_asset_prefix_to_the_outputted_file_name()
     {
         $asset = 'files/asset.css';


### PR DESCRIPTION
Your PR allows files to be missing from the manifest by passing `$strict = false`, however it may be desirable to also prevent exception if the file doesn't exist at all (if the file is being served via proxy, e.g. webpack dev server).

This prevents an exception from being thrown in the event that the file doesn't exist at all, and `$strict = false`.